### PR TITLE
attempt to gracefully avoid shnth

### DIFF
--- a/schicksalslied.lua
+++ b/schicksalslied.lua
@@ -351,7 +351,7 @@ function init()
   end
   print("schicksalslied")
   softcut_init()
-  sh = hid.connect()
+  sh = hid.connect(2)
   if sh.device then
       shnth = include("shnth/lib/shnth")
       sh.event = shnth.event

--- a/schicksalslied.lua
+++ b/schicksalslied.lua
@@ -5,7 +5,8 @@ LiedMotor = include('lib/LiedMotor_engine')
 MusicUtil = require "musicutil"
 sequins = require "sequins"
 fileselect = require 'fileselect'
-shnth = include("shnth/lib/shnth")
+-- shnth = include("shnth/lib/shnth")
+shnth = {}
 
 selectedfile = _path.dust.."audio/hermit_leaves.wav"
 
@@ -351,7 +352,10 @@ function init()
   print("schicksalslied")
   softcut_init()
   sh = hid.connect()
-  sh.event = shnth.event
+  if sh.device then
+      shnth = include("shnth/lib/shnth")
+      sh.event = shnth.event
+  end
   clock.run(step)
   clock.run(steptwo)
   clock.run(stepthree)


### PR DESCRIPTION
So initially `shnth` is defined to be the empty table (so that when you later define `shnth.functions` Lua doesn't freak out) but any HID device present when the script starts will be assumed to be a shnth and cause the script to go looking for the shnth code. Anyway, since I don't have one, check and see if it still works with your shnth?